### PR TITLE
Added windows support, basic logging, and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,36 @@
 _Composites main and overlay files from Snapchat into a single mp4 or jpg._
 
 ## Dependencies
-- ImageMagick
-- ffmpeg
+### System
+- ImageMagick (CLI binaries)
+- ffmpeg (CLI Binaries)
 - Python 3
-    - ffmpeg-python
 
+### Python
+- ffmpeg-python
+
+## Setup
+
+### Getting your data from Snapchat
+Go to https://accounts.snapchat.com/v2/download-my-data and complete the form to get your data compiled from Snapchat. Be sure to select the "Include your Memories, Chat Media and Shared Stories" option at the top and select an appropriate time frame for what you want downloaded. This process can take some time.
+
+### ImageMagick
+The downloadable binaries for ImageMagick can be found [here.](https://imagemagick.org/script/download.php)
+
+### ffmpeg
+The downloadable binaries for ffmpeg can be found [here.](https://ffmpeg.org/download.html)
+
+#### ffmpeg on Windows
+Binaries for Windows installations of ffmpeg are instead  hosted [here.](https://www.gyan.dev/ffmpeg/builds/#release-builds)
+
+When using the windows binaries, you have to add the contents of the `bin` folder to your system PATH. A very simple guide on how to do that is found [here.](https://www.architectryan.com/2018/03/17/add-to-the-path-on-windows-10/) 
 
 ## Usage
 
+Supported file typings are: `[".jpg",".png",".mp4"]`
+
 1. `pip3 install -r requirements.txt`
-2. Place your memories into a 'memories' in the root of this folder - make sure to delete anything that isn't an mp4 or jpg (e.g. memories.html, .DS_Store, etc).
-4. `python3 ./composite.py`
-_There will now be "composite" files within your memories folder, which are the main files with the overlay ontop._
+2. Place your memories into a 'memories' in the root of this folder
+    - The script should filter by supported file types and `file` types only. But should something be missed, delete anything that isn't supported (e.g. memories.html, .DS_Store, etc).
+3. `python3 ./composite.py`
+_A `composite` folder is created inside of your `memories` folder that contains the finalized files with their overlays on top._

--- a/composite.py
+++ b/composite.py
@@ -107,7 +107,10 @@ for file in memories_files_raw:
     elif os.path.isdir(f'./memories/{file}'):
         print(f"'./memories/{file}' is a directory. Skipping...")
     else:
-        raise Exception("UNSUPPORTED_FILE: " + f'./memories/{file}')
+        # since we filter the files that are parsed,
+        # there should be no need to throw an exception
+        # and halt the script
+        print("UNSUPPORTED_FILE: " + f'./memories/{file}')
 
 file_count = len(memories_files_filtered)
 print(f"You have {file_count} files to process. Beginning...")

--- a/composite.py
+++ b/composite.py
@@ -9,46 +9,38 @@ import shutil
 import platform
 from pathlib import Path
 
+def run_subprocess(commands,capture_output = False):
+    is_windows = platform.system == "Windows"
+
+    return subprocess.run(commands,shell=is_windows,capture_output=capture_output)
+
+
 def resize_image(image_path, dimensions, new_file):
-    if platform.system == 'Windows':
-        subprocess.run([
-            # magick convert ./memories/A-overlay.png -resize 998x1920 new.png
-            "magick",
-            "convert",
-            image_path,
-            "-resize",
-            str(dimensions["width"]) + "x" + str(dimensions["height"]),
-            new_file
-        ], shell=True)
-    else:   
-        subprocess.run([
-            # magick convert ./memories/A-overlay.png -resize 998x1920 new.png
-            "magick",
-            "convert",
-            image_path,
-            "-resize",
-            str(dimensions["width"]) + "x" + str(dimensions["height"]),
-            new_file
-        ])
+
+    resize_image_command = [
+        # magick convert ./memories/A-overlay.png -resize 998x1920 new.png
+        "magick",
+        "convert",
+        image_path,
+        "-resize",
+        str(dimensions["width"]) + "x" + str(dimensions["height"]),
+        new_file
+    ]
+
+    return run_subprocess(resize_image_command)
 
 
 def get_image_size(image_path):
-    if platform.system == 'Windows':
-        result = subprocess.run([
+    
+    get_image_command = [
             "magick",
             "identify",
             "-format",
             "%w %h",
             image_path
-        ],capture_output=True, shell=True)
-    else:
-        result = subprocess.run([
-            "magick",
-            "identify",
-            "-format",
-            "%w %h",
-            image_path
-        ],capture_output=True)
+    ]
+
+    result = run_subprocess(get_image_command,capture_output=True)
 
     result_string = result.stdout.decode("utf8")
 
@@ -59,8 +51,7 @@ def get_image_size(image_path):
 
 def composite_images(overlay_path, main_path, new_file):
     # magick composite new.png ./memories/A-main.jpg -compose over -gravity center composite.png
-    if platform.system() == "Windows":
-        subprocess.run([
+    composite_image_command = [
             "magick",
             "composite",
             overlay_path,
@@ -70,19 +61,9 @@ def composite_images(overlay_path, main_path, new_file):
             "-gravity",
             "center",
             new_file
-        ], shell=True)
-    else:
-        subprocess.run([
-            "magick",
-            "composite",
-            overlay_path,
-            main_path,
-            "-compose",
-            "over",
-            "-gravity",
-            "center",
-            new_file
-        ])
+    ]
+
+    return run_subprocess(composite_image_command)
 
 
 def move_composited_file(old_file_path, new_path):


### PR DESCRIPTION
This is actually my first pull request to a repo that isn't my own.

Cool program. Super helpful since previous programs seem to have stopped working with Snapchat removing the `memories.json` from the data exports. 

When I first tried this, it seemed like it only really worked on UNIX systems, given the addition of platform checks and adding `shell=True` to the subprocess calls for Windows systems. That got it nearly working. I then added an `r` to what is now line 139, for a literal string for the mp4 file path. It seemed to have issues without it.

I also attempted to improve your initial overlay for loop. I tried a list comprehension for checking if the file was a `file` rather than a `dir` then by file extension, but at the end of the day, it's a for loop underneath and genuine for loops are easier to read. So it's down from the two loops that constantly iterated over the supported file types list and files, to just checking files and their extension with an `in` check. These are filtered into a new list that should make handling non-supported file types and any subdirectories better, removing the need to remove them from the directory first.

I also changed the output so that everything is moved to a newly created `composite` folder after ffmpeg or ImageMagick do their thing. Helps to automate the workflow if you're trying to move the newly made files to something like immich or a NAS directory; rather than trying to parse file names for that `-composite` substring. 

I also added some really basic logging. Nothing big or that helpful, but enough so that you know the script is stilling running at least and hasn't hanged anywhere.

And then I updated the README to include some extra info. Should anyone finding this project need it.